### PR TITLE
Add CFBundleExecutable to app Info.plist

### DIFF
--- a/Sawmi/Info.plist
+++ b/Sawmi/Info.plist
@@ -4,6 +4,10 @@
 <dict>
     <key>CFBundleName</key>
     <string>Sawmi</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
     <key>CFBundleIdentifier</key>
     <string>com.mednordz.sawmi</string>
     <key>CFBundleVersion</key>


### PR DESCRIPTION
## Summary
- define `CFBundleExecutable` so the app bundle points to the correct binary
- declare the bundle `CFBundlePackageType` as an application

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_68b84d2559b883298a8238448a81f2fa