### PR TITLE
Secure credential storage with SHA256 hashing

### DIFF
--- a/Sawmi/Services/AuthService.swift
+++ b/Sawmi/Services/AuthService.swift
@@ -1,55 +1,71 @@
 import Foundation
 import Security
+import CryptoKit
 
 class AuthService: ObservableObject {
     static let shared = AuthService()
     @Published private(set) var currentUser: User?
 
     private let service = "com.sawmi.auth"
-    private let accountKey = "userId"
+    private let userIdKey = "userId"
+    private let emailKey = "email"
+    private let passwordKey = "passwordHash"
 
     private init() {
-        if let id = loadUserId() {
-            currentUser = User(id: id, email: "", passwordHash: "")
+        if let id = loadUserId(),
+           let email = loadValue(for: emailKey),
+           let hash = loadValue(for: passwordKey) {
+            currentUser = User(id: id, email: email, passwordHash: hash)
         }
     }
 
     func signUp(email: String, password: String) {
-        let user = User(id: UUID(), email: email, passwordHash: hash(password))
-        saveUserId(user.id)
+        let hashedPassword = hash(password)
+        let user = User(id: UUID(), email: email, passwordHash: hashedPassword)
+        saveValue(user.id.uuidString, for: userIdKey)
+        saveValue(email, for: emailKey)
+        saveValue(hashedPassword, for: passwordKey)
         currentUser = user
     }
 
     @discardableResult
     func signIn(email: String, password: String) -> Bool {
-        guard let id = loadUserId() else { return false }
-        currentUser = User(id: id, email: email, passwordHash: hash(password))
+        guard let storedEmail = loadValue(for: emailKey),
+              let storedHash = loadValue(for: passwordKey),
+              storedEmail == email,
+              hash(password) == storedHash,
+              let id = loadUserId() else {
+            return false
+        }
+        currentUser = User(id: id, email: email, passwordHash: storedHash)
         return true
     }
 
     func signOut() {
-        deleteUserId()
+        deleteValue(for: userIdKey)
+        deleteValue(for: emailKey)
+        deleteValue(for: passwordKey)
         currentUser = nil
     }
 
     // MARK: - Keychain
-    private func saveUserId(_ id: UUID) {
-        guard let data = id.uuidString.data(using: .utf8) else { return }
+    private func saveValue(_ value: String, for key: String) {
+        guard let data = value.data(using: .utf8) else { return }
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
-            kSecAttrAccount as String: accountKey,
+            kSecAttrAccount as String: key,
             kSecValueData as String: data
         ]
         SecItemDelete(query as CFDictionary)
         SecItemAdd(query as CFDictionary, nil)
     }
 
-    private func loadUserId() -> UUID? {
+    private func loadValue(for key: String) -> String? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
-            kSecAttrAccount as String: accountKey,
+            kSecAttrAccount as String: key,
             kSecReturnData as String: kCFBooleanTrue as Any,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
@@ -57,23 +73,29 @@ class AuthService: ObservableObject {
         let status = SecItemCopyMatching(query as CFDictionary, &item)
         guard status == errSecSuccess,
               let data = item as? Data,
-              let str = String(data: data, encoding: .utf8),
-              let uuid = UUID(uuidString: str) else {
+              let str = String(data: data, encoding: .utf8) else {
             return nil
         }
-        return uuid
+        return str
     }
 
-    private func deleteUserId() {
+    private func loadUserId() -> UUID? {
+        guard let str = loadValue(for: userIdKey) else { return nil }
+        return UUID(uuidString: str)
+    }
+
+    private func deleteValue(for key: String) {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
-            kSecAttrAccount as String: accountKey
+            kSecAttrAccount as String: key
         ]
         SecItemDelete(query as CFDictionary)
     }
 
     private func hash(_ password: String) -> String {
-        String(password.reversed())
+        let data = Data(password.utf8)
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
     }
 }


### PR DESCRIPTION
## Summary
- Replace simple password reversal with CryptoKit-based SHA256 hashing
- Store user ID, email, and password hash in the Keychain
- Validate sign-in against stored email and hashed password

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_68b85d6d60b8832995656e06cd5e990b