### PR TITLE
Show error on failed sign-in

### DIFF
--- a/Sawmi/Views/AuthView.swift
+++ b/Sawmi/Views/AuthView.swift
@@ -4,6 +4,7 @@ struct AuthView: View {
     @State private var email = ""
     @State private var password = ""
     @ObservedObject private var auth = AuthService.shared
+    @State private var signInFailed = false
 
     var body: some View {
         VStack(spacing: 16) {
@@ -18,7 +19,12 @@ struct AuthView: View {
                 .background(Color.gray.opacity(0.2))
                 .cornerRadius(8)
             Button(NSLocalizedString("sign_in", comment: "sign in")) {
-                _ = auth.signIn(email: email, password: password)
+                let success = auth.signIn(email: email, password: password)
+                signInFailed = !success
+            }
+            if signInFailed {
+                Text(NSLocalizedString("auth_failed", comment: "authentication failed"))
+                    .foregroundColor(.red)
             }
             Button(NSLocalizedString("sign_up", comment: "sign up")) {
                 auth.signUp(email: email, password: password)

--- a/Sawmi/en.lproj/Localizable.strings
+++ b/Sawmi/en.lproj/Localizable.strings
@@ -21,3 +21,4 @@
 "password" = "Password";
 "sign_in" = "Sign In";
 "sign_up" = "Sign Up";
+"auth_failed" = "Authentication failed";

--- a/Sawmi/fr.lproj/Localizable.strings
+++ b/Sawmi/fr.lproj/Localizable.strings
@@ -21,3 +21,4 @@
 "password" = "Mot de passe";
 "sign_in" = "Se connecter";
 "sign_up" = "S'inscrire";
+"auth_failed" = "Échec de l'authentification";


### PR DESCRIPTION
## Summary
- capture sign-in result and toggle error flag
- display localized message when authentication fails
- add `auth_failed` translations for English and French

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_b_68b85d6ea2c883298b4140f85831ec58